### PR TITLE
Parallelize remaining appraisal commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Please file a bug if you notice a violation of semantic versioning.
 
 ### Fixed
 
+- Appraisal command execution now checks whether the `bundle` executable can
+  boot before falling back to RubyGems spec probing and Bundler installation,
+  preserving TruffleRuby's engine-shipped Bundler in isolated subprocesses.
+
 ### Security
 
 ## [3.1.4] - 2026-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Please file a bug if you notice a violation of semantic versioning.
   preserving TruffleRuby's engine-shipped Bundler in isolated subprocesses.
 - Acceptance fixture Bundler selection now detects TruffleRuby's shipped
   Bundler without reusing a newer Bundler activated by the appraised suite.
+- Acceptance fixture binstubs now pin the selected Bundler version before
+  loading generated `bin/bundle` handoff code.
 - Bundler-backed appraisal installs now set `BUNDLE_JOBS` explicitly so the
   configured Appraisal job count also controls Bundler's installer worker
   count in subprocesses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Please file a bug if you notice a violation of semantic versioning.
 - Appraisal command execution now checks whether the `bundle` executable can
   boot before falling back to RubyGems spec probing and Bundler installation,
   preserving TruffleRuby's engine-shipped Bundler in isolated subprocesses.
+- Acceptance fixture Bundler selection now detects TruffleRuby's shipped
+  Bundler without reusing a newer Bundler activated by the appraised suite.
 - Bundler-backed appraisal installs now set `BUNDLE_JOBS` explicitly so the
   configured Appraisal job count also controls Bundler's installer worker
   count in subprocesses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Please file a bug if you notice a violation of semantic versioning.
 - Appraisal command execution now checks whether the `bundle` executable can
   boot before falling back to RubyGems spec probing and Bundler installation,
   preserving TruffleRuby's engine-shipped Bundler in isolated subprocesses.
+- Bundler-backed appraisal installs now set `BUNDLE_JOBS` explicitly so the
+  configured Appraisal job count also controls Bundler's installer worker
+  count in subprocesses.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,11 @@ Please file a bug if you notice a violation of semantic versioning.
 
 ### Added
 
-- `appraisal generate` can now generate appraisal Gemfiles in parallel with
-  `--jobs` / `-j`, or `APPRAISAL_JOBS`.
+- `appraisal generate`, `install`, `update`, `generate-install`, and
+  `generate-update` can now process appraisals in parallel with
+  `--appraisal-jobs` / `-n`, or `APPRAISAL_JOBS`. Appraisal-level
+  parallelism defaults to 2 workers; use `-n 1` to run serially. Bundler older
+  than 2.1 falls back to serial processing.
 
 ### Changed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,4 +443,4 @@ DEPENDENCIES
   yard-yaml (~> 0.2, >= 0.2.3)
 
 BUNDLED WITH
-  4.0.14
+  4.0.16

--- a/README.md
+++ b/README.md
@@ -259,10 +259,20 @@ Use the command that matches the lifecycle you want:
 | `generate-install` | Yes | Yes, via install | First setup, or after intentional Appraisals changes |
 | `generate-update` | Yes | Yes, via update | Regenerate gemfiles, then update dependency locks |
 
-`generate`, `generate-install`, and `generate-update` can generate appraisal
-gemfiles in parallel with `--jobs` / `-j`, or with `APPRAISAL_JOBS` when no
-CLI value is provided. `generate-install` and `generate-update` parallelize the
-generation phase, then resolve dependencies with the selected gem manager.
+Appraisal2 can process appraisals in parallel with `--appraisal-jobs` / `-n`,
+or with `APPRAISAL_JOBS` when no CLI value is provided. `generate`,
+`generate-install`, and `generate-update` use this for generation. `install`,
+`update`, `generate-install`, and `generate-update` use it to fan out dependency
+resolution across appraisals. External commands run across all appraisals, such
+as `bundle exec appraisal rake test`, use `APPRAISAL_JOBS`. Appraisal-level
+parallelism defaults to 2 workers; use `-n 1` to run serially. When Appraisal2
+is running under Bundler older than 2.1, Appraisal2 falls back to serial
+processing because those Bundler versions do not provide the modern environment
+helpers used to isolate parallel Bundler subprocesses.
+
+Install commands keep `--jobs` / `-j` for the selected gem manager. With
+Bundler, `-j` controls `bundle install --jobs`, while `-n` controls how many
+appraisal gemfiles Appraisal2 processes at the same time.
 
 The deprecated rake task `rake appraisal:install` now delegates to `appraisal generate-install`, preserving its historical generate-and-install behavior while the CLI commands remain explicit.
 
@@ -275,11 +285,26 @@ Built-in dependency commands support the following options:
 | Option | Description |
 |--------|-------------|
 | `--gem-manager`, `-g` | Gem manager to use: `bundler` (default) or `ore`; applies to `install`, `update`, `generate-install`, and `generate-update` |
-| `--jobs`, `-j` | Generate appraisal gemfiles in parallel for `generate`, `generate-install`, and `generate-update`; also installs gems in parallel for `install` and `generate-install` when supported by the selected gem manager |
+| `--appraisal-jobs`, `-n` | Process appraisals in parallel for `generate`, `install`, `update`, `generate-install`, and `generate-update` (default: 2; use `-n 1` for serial execution; Bundler < 2.1 falls back to serial processing) |
+| `--jobs`, `-j` | Pass a parallel job count to the selected gem manager; applies to `install` and `generate-install` |
 | `--retry` | Retry network and git requests that have failed; applies to `install` and `generate-install` (default: 1) |
 | `--without` | A space-separated list of groups to skip during installation; applies to `install` and `generate-install` |
 | `--full-index` | Run bundle install with the full-index argument; applies to `install` and `generate-install` |
 | `--path` | Install gems in the specified directory; applies to `install` and `generate-install` |
+
+```bash
+# Process two appraisals at a time, using the default Appraisal worker count
+bundle exec appraisal generate-install
+
+# Process four appraisals at a time
+bundle exec appraisal generate-install -n 4
+
+# Process two appraisals at a time, and give each Bundler install four jobs
+bundle exec appraisal generate-install -n 2 -j 4
+
+# Run Appraisal serially when parallel appraisal processing is not desired
+bundle exec appraisal generate-install -n 1
+```
 
 ### Using Commands with Named Appraisals
 

--- a/lib/appraisal/appraisal.rb
+++ b/lib/appraisal/appraisal.rb
@@ -94,7 +94,7 @@ module Appraisal
     end
 
     def gemfile_path
-      gemfile_root.mkdir unless gemfile_root.exist?
+      FileUtils.mkdir_p(gemfile_root)
 
       gemfile_root.join(gemfile_name).to_s
     end

--- a/lib/appraisal/cli.rb
+++ b/lib/appraisal/cli.rb
@@ -6,14 +6,23 @@ require "thread"
 
 module Appraisal
   class CLI < Thor
+    MINIMUM_PARALLEL_BUNDLER_VERSION = Gem::Version.new("2.1.0")
+
     default_task :install
     map ["-v", "--version"] => "version"
+    map "generate-install" => "generate_install"
+    map "generate-update" => "generate_update"
 
     class_option "gem-manager",
       :aliases => "-g",
       :type => :string,
       :default => "bundler",
       :desc => "Gem manager to use for install/update (bundler or ore)"
+    class_option "appraisal-jobs",
+      :aliases => "-n",
+      :type => :numeric,
+      :banner => "SIZE",
+      :desc => "Process appraisals in parallel using the given number of workers."
 
     class << self
       # Override help command to print out usage
@@ -60,7 +69,7 @@ module Appraisal
       :type => :numeric,
       :default => 1,
       :banner => "SIZE",
-      :desc => "Install gems in parallel using the given number of workers."
+      :desc => "Pass the given parallel job count to the selected gem manager."
     method_option "retry",
       :type => :numeric,
       :default => 1,
@@ -79,7 +88,7 @@ module Appraisal
         "Bundler will remember this option."
 
     def install
-      install_appraisals(appraisals, install_options)
+      install_appraisals(appraisals, install_options, appraisal_jobs(options))
     end
 
     desc "generate-install", "Generate gemfiles, then resolve and install dependencies for each appraisal"
@@ -88,7 +97,7 @@ module Appraisal
       :type => :numeric,
       :default => 1,
       :banner => "SIZE",
-      :desc => "Install gems in parallel using the given number of workers."
+      :desc => "Pass the given parallel job count to the selected gem manager."
     method_option "retry",
       :type => :numeric,
       :default => 1,
@@ -107,18 +116,13 @@ module Appraisal
         "Bundler will remember this option."
     def generate_install
       appraisal_list = appraisals
-      generate_appraisals(appraisal_list, generate_jobs(options))
-      install_appraisals(appraisal_list, install_options)
+      generate_appraisals(appraisal_list, appraisal_jobs(options))
+      install_appraisals(appraisal_list, install_options, appraisal_jobs(options))
     end
 
     desc "generate", "Generate a gemfile for each appraisal"
-    method_option "jobs",
-      :aliases => "j",
-      :type => :numeric,
-      :banner => "SIZE",
-      :desc => "Generate appraisal gemfiles in parallel using the given number of workers."
     def generate
-      generate_appraisals(appraisals, generate_jobs(options))
+      generate_appraisals(appraisals, appraisal_jobs(options))
     end
 
     desc "clean", "Remove all generated gemfiles and lockfiles from gemfiles folder"
@@ -128,19 +132,14 @@ module Appraisal
 
     desc "update [LIST_OF_GEMS]", "Update dependencies for each generated appraisal gemfile"
     def update(*gems)
-      update_appraisals(appraisals, gems, update_options)
+      update_appraisals(appraisals, gems, update_options, appraisal_jobs(options))
     end
 
     desc "generate-update [LIST_OF_GEMS]", "Generate gemfiles, then update dependencies for each appraisal"
-    method_option "jobs",
-      :aliases => "j",
-      :type => :numeric,
-      :banner => "SIZE",
-      :desc => "Generate appraisal gemfiles in parallel using the given number of workers."
     def generate_update(*gems)
       appraisal_list = appraisals
-      generate_appraisals(appraisal_list, generate_jobs(options))
-      update_appraisals(appraisal_list, gems, update_options)
+      generate_appraisals(appraisal_list, appraisal_jobs(options))
+      update_appraisals(appraisal_list, gems, update_options, appraisal_jobs(options))
     end
 
     desc "list", "List the names of the defined appraisals"
@@ -165,15 +164,15 @@ module Appraisal
       end
     end
 
-    def install_appraisals(appraisal_list, install_options)
-      appraisal_list.each do |appraisal|
+    def install_appraisals(appraisal_list, install_options, jobs)
+      each_appraisal(appraisal_list, jobs) do |appraisal|
         appraisal.install(install_options.dup)
         appraisal.relativize
       end
     end
 
-    def update_appraisals(appraisal_list, gems, update_options)
-      appraisal_list.each do |appraisal|
+    def update_appraisals(appraisal_list, gems, update_options, jobs)
+      each_appraisal(appraisal_list, jobs) do |appraisal|
         appraisal.update(gems, update_options.dup)
       end
     end
@@ -210,17 +209,29 @@ module Appraisal
     def worker_count(jobs, item_count)
       jobs = jobs.to_i
       jobs = 1 if jobs < 1
+      jobs = 1 unless parallel_appraisals_supported?
       return jobs if item_count.zero?
 
       [jobs, item_count].min
     end
 
-    def generate_jobs(command_options)
-      command_options["jobs"] || command_options[:jobs] || ENV["APPRAISAL_JOBS"] || 1
+    def parallel_appraisals_supported?
+      # Parallel install/update workers depend on Appraisal::Command being able
+      # to build independent Bundler subprocess environments. Bundler 2.1 is the
+      # floor for the modern original_env/unbundled_env API split that replaced
+      # clean_env, so older Bundler versions keep the historical serial path.
+      bundler_version = Gem::Specification.find_all_by_name("bundler").map(&:version).max
+      return false unless bundler_version
+
+      bundler_version >= MINIMUM_PARALLEL_BUNDLER_VERSION
+    end
+
+    def appraisal_jobs(command_options)
+      command_options["appraisal-jobs"] || command_options[:appraisal_jobs] || ENV["APPRAISAL_JOBS"] || 2
     end
 
     def install_options
-      options.to_h
+      options.to_h.reject { |key, _value| key.to_s == "appraisal-jobs" }
     end
 
     def update_options
@@ -229,6 +240,13 @@ module Appraisal
     end
 
     def method_missing(name, *args)
+      case name.to_s
+      when "generate-install"
+        return generate_install
+      when "generate-update"
+        return generate_update(*args)
+      end
+
       matching_appraisal = AppraisalFile.new.appraisals.detect do |appraisal|
         appraisal.name == name.to_s
       end
@@ -289,7 +307,7 @@ module Appraisal
           Command.new(actual_args, :gemfile => matching_appraisal.gemfile_path).run
         end
       else
-        AppraisalFile.each do |appraisal|
+        each_appraisal(AppraisalFile.new.appraisals, appraisal_jobs(options)) do |appraisal|
           Command.new(ARGV, :gemfile => appraisal.gemfile_path).run
         end
       end
@@ -316,6 +334,17 @@ module Appraisal
           options[:jobs] = Regexp.last_match(1).to_i
         when /^-j(\d+)$/
           options[:jobs] = Regexp.last_match(1).to_i
+        when /^-j$/
+          options[:jobs] = args[index + 1].to_i
+          skip_next = true
+        when /^--appraisal-jobs=\d+$/
+          nil
+        when /^--appraisal-jobs$/
+          skip_next = true
+        when /^-n\d+$/
+          nil
+        when /^-n$/
+          skip_next = true
         when /^--retry=(\d+)$/
           options[:retry] = Regexp.last_match(1).to_i
         when /^--without=(.+)$/
@@ -346,6 +375,10 @@ module Appraisal
         when /^-g$/
           # Next arg should be the value
           options[:gem_manager] = args[index + 1]
+          skip_next = true
+        when /^--appraisal-jobs$/
+          skip_next = true
+        when /^-n$/
           skip_next = true
         when /^-/
           # Other options are not gems, but we don't handle them all here

--- a/lib/appraisal/command.rb
+++ b/lib/appraisal/command.rb
@@ -8,7 +8,9 @@ module Appraisal
     attr_reader :command, :env, :gemfile
 
     # BUNDLE_* environment variables that must be preserved for proper bundler operation
-    # and test isolation. These are preserved when using with_bundler_env to ensure:
+    # and test isolation. These are preserved after starting from Bundler's
+    # unbundled environment so Appraisal can run a fresh Bundler subprocess
+    # without losing the target appraisal and isolation settings:
     # - Bundler version switching works (BUNDLE_GEMFILE)
     # - Test isolation is maintained (BUNDLE_APP_CONFIG, etc.)
     # - User settings are respected (BUNDLE_PATH, BUNDLE_USER_CACHE, etc.)
@@ -30,6 +32,7 @@ module Appraisal
 
     PRESERVED_RUNTIME_VARS = [
       "PATH",
+      "GEM_HOME",
       "GEM_PATH"
     ].freeze
 
@@ -44,101 +47,105 @@ module Appraisal
       run_env = test_environment.merge(env)
 
       if @skip_bundle_exec
-        execute(run_env)
+        execute(ENV.to_h, run_env)
       else
-        # For bundler version switching to work reliably, we need to preserve
-        # the appraisal Gemfile while avoiding the active parent Bundler process.
-        # However, we still need to isolate from the parent's bundler state
-        # to avoid conflicts.
-        #
-        # Solution: Use a selective environment approach instead of with_original_env,
-        # which strips all BUNDLE_* variables and breaks version switching.
-        with_bundler_env do
-          apply_run_env(run_env)
-          ensure_bundler_is_available
-          ensure_locked_bundler_is_available
-          execute(run_env)
-        end
+        clean_env = bundler_env(run_env)
+        ensure_bundler_is_available(clean_env)
+        ensure_locked_bundler_is_available(clean_env)
+        execute(clean_env, run_env)
       end
     end
 
     private
 
-    # Provide a clean environment while preserving Bundler's version switching
-    # inputs and test isolation settings.
+    # Build an Appraisal subprocess environment from Bundler's explicit env APIs.
     #
-    # The current Ruby process has bundler activated, which adds bundler/setup to RUBYOPT.
-    # When we run a subprocess, we need to remove that activation so the subprocess bundler
-    # can start fresh. However, we keep all test isolation variables intact.
-    def with_bundler_env
-      backup_env = ENV.to_h
-
-      begin
-        clean_env = if Bundler.respond_to?(:original_env)
-          Bundler.original_env.to_h
-        else
-          backup_env.to_h
-        end
-
-        # Avoid leaking a global BUNDLE_LOCKFILE into subprocesses.
-        clean_env.delete("BUNDLE_LOCKFILE")
-
-        preserved_vars = PRESERVED_BUNDLE_VARS + PRESERVED_RUNTIME_VARS
-
-        preserved_vars.each do |var|
-          clean_env[var] = backup_env[var] if backup_env[var]
-        end
-
-        # Remove bundler/setup from RUBYOPT so subprocess doesn't auto-load bundler
-        if backup_env["RUBYOPT"]
-          rubyopt = backup_env["RUBYOPT"].split(" ")
-          rubyopt.reject! { |opt| opt == "-rbundler/setup" || opt.include?("bundler/setup") }
-          clean_env["RUBYOPT"] = rubyopt.join(" ") unless rubyopt.empty?
-        end
-
-        # Remove Bundler activation markers from the subprocess environment.
-        # BUNDLE_BIN_PATH pins the already-active Bundler executable, so keeping
-        # it would bypass the BUNDLED WITH version selected below.
-        clean_env.delete("BUNDLE_BIN_PATH")
-        clean_env.delete("BUNDLER_SETUP")
-        clean_env.delete("BUNDLER_VERSION")
-
-        ENV.replace(clean_env)
-
-        yield
-      ensure
-        ENV.replace(backup_env)
+    # Bundler.clean_env / Bundler.with_clean_env are removed. Bundler now exposes
+    # three related but distinct choices:
+    #
+    # - Bundler.original_env: the environment before the current Bundler activated.
+    #   This is too broad for Appraisal because unrelated original BUNDLE_* values
+    #   can leak into the appraisal subprocess.
+    # - Bundler.unbundled_env: original_env with Bundler activation removed. This
+    #   is the right base because it removes parent Bundler state, RUBYOPT
+    #   bundler/setup activation, and arbitrary BUNDLE_* values.
+    # - Bundler.with_unbundled_env: the block form of unbundled_env. Appraisal
+    #   needs a Hash to pass to Kernel.system and must re-add selected variables,
+    #   so the block helper is the wrong shape even though its semantics are close.
+    #
+    # Starting from unbundled_env would normally remove BUNDLE_GEMFILE,
+    # BUNDLE_APP_CONFIG, and related isolation knobs. Appraisal intentionally
+    # reintroduces only the variables it owns or must preserve, then sets
+    # BUNDLE_GEMFILE and the selected Bundler version for the target subprocess.
+    def bundler_env(run_env)
+      current_env = ENV.to_h
+      clean_env = if defined?(Bundler) && Bundler.respond_to?(:unbundled_env)
+        Bundler.unbundled_env.to_h
+      elsif defined?(Bundler) && Bundler.respond_to?(:original_env)
+        Bundler.original_env.to_h
+      else
+        current_env.to_h
       end
+
+      # Avoid leaking a global BUNDLE_LOCKFILE into subprocesses.
+      clean_env["BUNDLE_LOCKFILE"] = nil
+
+      preserved_vars = PRESERVED_BUNDLE_VARS + PRESERVED_RUNTIME_VARS
+
+      preserved_vars.each do |var|
+        clean_env[var] = current_env[var] if current_env[var]
+      end
+
+      clean_env["RUBYOPT"] = current_env["RUBYOPT"] if current_env["RUBYOPT"]
+
+      # Remove bundler/setup from RUBYOPT so subprocess doesn't auto-load bundler.
+      # Bundler.original_env can also contain RUBYOPT, so strip from the final
+      # command environment rather than only from the active process env.
+      if clean_env["RUBYOPT"]
+        rubyopt = clean_env["RUBYOPT"].split(" ")
+        rubyopt.reject! { |opt| opt == "-rbundler/setup" || opt.include?("bundler/setup") }
+        clean_env["RUBYOPT"] = rubyopt.join(" ")
+        clean_env["RUBYOPT"] = nil if clean_env["RUBYOPT"].empty?
+      end
+
+      # Remove Bundler activation markers from the subprocess environment.
+      # BUNDLE_BIN_PATH pins the already-active Bundler executable, so keeping
+      # it would bypass the BUNDLED WITH version selected below.
+      clean_env["BUNDLE_BIN_PATH"] = nil
+      clean_env["BUNDLE_VERSION"] = nil
+      clean_env["BUNDLER_SETUP"] = nil
+      clean_env["BUNDLER_VERSION"] = nil
+
+      run_env.each_pair do |key, value|
+        clean_env[key] = value
+      end
+
+      clean_env
     end
 
-    def execute(run_env)
+    def execute(base_env, run_env)
       announce
 
-      ENV["BUNDLE_GEMFILE"] = gemfile
-      if (bundler_version = locked_bundler_version)
-        ENV["BUNDLER_VERSION"] = bundler_version
+      process_env = base_env.merge(run_env)
+      process_env["BUNDLE_GEMFILE"] = gemfile if gemfile
+      if (bundler_version = subprocess_bundler_version(process_env))
+        process_env["BUNDLE_VERSION"] = bundler_version
+        process_env["BUNDLER_VERSION"] = bundler_version
       end
-      ENV["APPRAISAL_INITIALIZED"] = "1"
-      run_env.each_pair do |key, value|
-        ENV[key] = value
-      end
+      process_env["APPRAISAL_INITIALIZED"] = "1"
 
-      exit(1) unless Kernel.system(command_as_string)
+      exit(1) unless Kernel.system(process_env, command_as_string)
     end
 
-    def apply_run_env(run_env)
-      run_env.each_pair do |key, value|
-        ENV[key] = value
-      end
-    end
+    def ensure_bundler_is_available(process_env)
+      rubygems_env = rubygems_command_env(process_env)
 
-    def ensure_bundler_is_available
       # Check if any version of bundler is available
-      return if system(%(gem list --silent -i bundler))
+      return if system(rubygems_env, bundler_available_command)
 
       puts ">> Bundler not found, attempting to install..."
       # If that fails, try to install the latest stable version
-      return if system("gem install bundler")
+      return if system(rubygems_env, "ruby --disable=gems -S gem install bundler")
 
       puts
       puts <<-ERROR.rstrip
@@ -150,14 +157,16 @@ manually.
       exit(1)
     end
 
-    def ensure_locked_bundler_is_available
+    def ensure_locked_bundler_is_available(process_env)
       locked_version = locked_bundler_version
       return unless locked_version
 
-      return if system(%(gem list --silent -i bundler -v "#{locked_version}"))
+      rubygems_env = rubygems_command_env(process_env)
+
+      return if system(rubygems_env, bundler_available_command(locked_version))
 
       puts ">> Bundler #{locked_version} not found, attempting to install..."
-      return if system("gem install bundler -v #{Shellwords.escape(locked_version)} --no-document")
+      return if system(rubygems_env, "ruby --disable=gems -S gem install bundler -v #{Shellwords.escape(locked_version)} --no-document")
 
       puts
       puts <<-ERROR.rstrip
@@ -178,6 +187,37 @@ manually.
       lockfile_content = File.read(lockfile_path)
       match = lockfile_content.match(/BUNDLED WITH\s*\n\s*([^\s]+)/)
       match && match[1]
+    end
+
+    def subprocess_bundler_version(process_env)
+      # Production subprocesses pin Bundler only when the appraisal lockfile
+      # says to. Acceptance specs may provide APPRAISAL_TEST_BUNDLER_VERSION so
+      # the nested subprocesses use the same isolated Bundler selected by the
+      # harness, without changing production behavior.
+      locked_bundler_version || process_env["APPRAISAL_TEST_BUNDLER_VERSION"]
+    end
+
+    def rubygems_command_env(process_env)
+      process_env.dup.tap do |env|
+        env["BUNDLE_APP_CONFIG"] = nil
+        env["BUNDLE_BIN_PATH"] = nil
+        env["BUNDLE_GEMFILE"] = nil
+        env["BUNDLE_LOCKFILE"] = nil
+        env["BUNDLE_VERSION"] = nil
+        env["BUNDLER_SETUP"] = nil
+        env["BUNDLER_VERSION"] = nil
+        env["RUBYOPT"] = nil
+      end
+    end
+
+    def bundler_available_command(version = nil)
+      requirement = version ? ", Gem::Requirement.new(#{version.inspect})" : ""
+      code = <<-RUBY.chomp
+        require "rubygems"
+        specs = Gem::Specification.find_all_by_name("bundler"#{requirement})
+        exit(specs.empty? ? 1 : 0)
+      RUBY
+      "ruby --disable=gems -e #{Shellwords.escape(code)}"
     end
 
     def announce
@@ -219,7 +259,7 @@ manually.
 
       {
         "GEM_HOME" => ENV["GEM_HOME"],
-        "GEM_PATH" => ""
+        "GEM_PATH" => ENV["APPRAISAL_TEST_SYSTEM_GEM_PATH"].to_s
       }
     end
   end

--- a/lib/appraisal/command.rb
+++ b/lib/appraisal/command.rb
@@ -140,7 +140,13 @@ module Appraisal
     def ensure_bundler_is_available(process_env)
       rubygems_env = rubygems_command_env(process_env)
 
-      # Check if any version of bundler is available
+      # First ask the actual Bundler executable whether it can boot. In CI,
+      # especially on alternate Ruby engines, Bundler may be available as the
+      # engine-shipped executable while a manually scrubbed RubyGems spec lookup
+      # cannot see it through the current GEM_HOME/GEM_PATH.
+      return if system(rubygems_env, "bundle -v > /dev/null 2>&1")
+
+      # Check if any version of bundler is available through RubyGems.
       return if system(rubygems_env, bundler_available_command)
 
       puts ">> Bundler not found, attempting to install..."

--- a/lib/appraisal/command.rb
+++ b/lib/appraisal/command.rb
@@ -140,11 +140,12 @@ module Appraisal
     def ensure_bundler_is_available(process_env)
       rubygems_env = rubygems_command_env(process_env)
 
-      # First ask the actual Bundler executable whether it can boot. In CI,
-      # especially on alternate Ruby engines, Bundler may be available as the
-      # engine-shipped executable while a manually scrubbed RubyGems spec lookup
-      # cannot see it through the current GEM_HOME/GEM_PATH.
-      return if system(rubygems_env, "bundle -v > /dev/null 2>&1")
+      # First ask the actual Bundler executable whether it can boot in the
+      # environment Appraisal is about to use. In CI, especially on alternate
+      # Ruby engines, Bundler may be available through the active app bundle
+      # while a manually scrubbed RubyGems spec lookup cannot see it through the
+      # current GEM_HOME/GEM_PATH.
+      return if system(process_env, "bundle -v > /dev/null 2>&1")
 
       # Check if any version of bundler is available through RubyGems.
       return if system(rubygems_env, bundler_available_command)

--- a/lib/appraisal/gem_manager/bundler_adapter.rb
+++ b/lib/appraisal/gem_manager/bundler_adapter.rb
@@ -96,11 +96,13 @@ module Appraisal
       end
 
       def install_environment(options)
-        env = {}
+        env = {"BUNDLE_JOBS" => DEFAULT_INSTALL_OPTIONS.fetch("jobs").to_s}
 
         if options["path"].nil? && Bundler.settings[:path]
           env["BUNDLE_DISABLE_SHARED_GEMS"] = "1"
         end
+
+        env["BUNDLE_JOBS"] = options["jobs"].to_s if options["jobs"].to_i > 1 && Utils.support_parallel_installation?
 
         env
       end

--- a/spec/appraisal/appraisal_spec.rb
+++ b/spec/appraisal/appraisal_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe Appraisal::Appraisal do
 
       expect(Appraisal::Command).to have_received(:new).with(
         "bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory'",
+        :env => {"BUNDLE_JOBS" => "1"},
         :gemfile => "/home/test/test directory"
       )
       expect(warning).to include "Please upgrade Bundler"
@@ -137,6 +138,7 @@ RSpec.describe Appraisal::Appraisal do
 
       expect(Appraisal::Command).to have_received(:new).with(
         "bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory' --jobs=42",
+        :env => {"BUNDLE_JOBS" => "42"},
         :gemfile => "/home/test/test directory"
       )
     end
@@ -146,6 +148,7 @@ RSpec.describe Appraisal::Appraisal do
 
       expect(Appraisal::Command).to have_received(:new).with(
         "bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory' --retry 3",
+        :env => {"BUNDLE_JOBS" => "1"},
         :gemfile => "/home/test/test directory"
       )
     end
@@ -156,6 +159,7 @@ RSpec.describe Appraisal::Appraisal do
       expect(Appraisal::Command).to have_received(:new).with(
         "bundle config set --local path /home/test/vendor/appraisal && " \
           "(bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory')",
+        :env => {"BUNDLE_JOBS" => "1"},
         :gemfile => "/home/test/test directory"
       )
     end
@@ -169,6 +173,7 @@ RSpec.describe Appraisal::Appraisal do
 
       expect(Appraisal::Command).to have_received(:new).with(
         "bundle check --gemfile='/home/test/test directory' || bundle install --gemfile='/home/test/test directory'",
+        :env => {"BUNDLE_JOBS" => "1"},
         :gemfile => "/home/test/test directory"
       )
     end

--- a/spec/appraisal/cli_spec.rb
+++ b/spec/appraisal/cli_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Appraisal::CLI do
     let(:first_appraisal) { instance_double(Appraisal::Appraisal, :write_gemfile => true) }
     let(:second_appraisal) { instance_double(Appraisal::Appraisal, :write_gemfile => true) }
 
-    it "generates appraisal gemfiles in parallel when jobs is greater than one" do
+    it "generates appraisal gemfiles in parallel when appraisal jobs is greater than one" do
       runner = nil
 
       begin
@@ -39,7 +39,7 @@ RSpec.describe Appraisal::CLI do
 
         allow(cli).to receive_messages(
           :appraisals => [first_appraisal, second_appraisal],
-          :options => {"jobs" => 2}
+          :options => {"appraisal-jobs" => 2}
         )
         [first_appraisal, second_appraisal].each do |current_appraisal|
           allow(current_appraisal).to receive(:write_gemfile) do
@@ -63,7 +63,7 @@ RSpec.describe Appraisal::CLI do
       end
     end
 
-    it "uses APPRAISAL_JOBS when jobs is not passed" do
+    it "uses APPRAISAL_JOBS when appraisal jobs is not passed" do
       stub_env("APPRAISAL_JOBS" => "2")
       allow(cli).to receive_messages(
         :appraisals => [first_appraisal, second_appraisal],
@@ -72,6 +72,82 @@ RSpec.describe Appraisal::CLI do
       expect(cli).to receive(:generate_appraisals).with([first_appraisal, second_appraisal], "2")
 
       cli.generate
+    end
+
+    it "defaults to two appraisal workers" do
+      allow(cli).to receive_messages(
+        :appraisals => [first_appraisal, second_appraisal],
+        :options => {}
+      )
+      expect(cli).to receive(:generate_appraisals).with([first_appraisal, second_appraisal], 2)
+
+      cli.generate
+    end
+
+    it "allows explicit serial appraisal processing" do
+      allow(cli).to receive_messages(
+        :appraisals => [first_appraisal, second_appraisal],
+        :options => {"appraisal-jobs" => 1}
+      )
+      expect(cli).to receive(:generate_appraisals).with([first_appraisal, second_appraisal], 1)
+
+      cli.generate
+    end
+  end
+
+  describe "#install" do
+    let(:first_appraisal) { instance_double(Appraisal::Appraisal, :install => true, :relativize => true) }
+    let(:second_appraisal) { instance_double(Appraisal::Appraisal, :install => true, :relativize => true) }
+
+    it "uses separate job counts for appraisal workers and gem manager workers" do
+      allow(cli).to receive_messages(
+        :appraisals => [first_appraisal, second_appraisal],
+        :options => {"appraisal-jobs" => 2, "jobs" => 4}
+      )
+
+      expect(cli).to receive(:each_appraisal).with([first_appraisal, second_appraisal], 2).and_call_original
+
+      cli.install
+
+      expect(first_appraisal).to have_received(:install).with(hash_including("jobs" => 4))
+      expect(second_appraisal).to have_received(:install).with(hash_including("jobs" => 4))
+      expect(first_appraisal).not_to have_received(:install).with(hash_including("appraisal-jobs" => 2))
+      expect(second_appraisal).not_to have_received(:install).with(hash_including("appraisal-jobs" => 2))
+    end
+  end
+
+  describe "#update" do
+    let(:first_appraisal) { instance_double(Appraisal::Appraisal, :update => true) }
+    let(:second_appraisal) { instance_double(Appraisal::Appraisal, :update => true) }
+
+    it "updates appraisals in parallel when appraisal jobs is greater than one" do
+      allow(cli).to receive_messages(
+        :appraisals => [first_appraisal, second_appraisal],
+        :options => {"appraisal-jobs" => 2}
+      )
+
+      expect(cli).to receive(:each_appraisal).with([first_appraisal, second_appraisal], 2).and_call_original
+
+      cli.update("rack")
+
+      expect(first_appraisal).to have_received(:update).with(["rack"], {})
+      expect(second_appraisal).to have_received(:update).with(["rack"], {})
+    end
+  end
+
+  describe "#worker_count" do
+    it "uses requested workers when Bundler is modern enough for isolated parallel subprocesses" do
+      bundler_spec = instance_double(Gem::Specification, :version => Gem::Version.new("2.1.0"))
+      allow(Gem::Specification).to receive(:find_all_by_name).with("bundler").and_return([bundler_spec])
+
+      expect(cli.send(:worker_count, 2, 3)).to eq(2)
+    end
+
+    it "falls back to serial processing when Bundler is older than the isolation floor" do
+      bundler_spec = instance_double(Gem::Specification, :version => Gem::Version.new("1.17.3"))
+      allow(Gem::Specification).to receive(:find_all_by_name).with("bundler").and_return([bundler_spec])
+
+      expect(cli.send(:worker_count, 2, 3)).to eq(1)
     end
   end
 
@@ -183,6 +259,37 @@ RSpec.describe Appraisal::CLI do
         cli.send(:method_missing, :"rails-7", "rake", "test")
       end
     end
+
+    context "when no appraisal name matches" do
+      let(:first_appraisal) do
+        instance_double(Appraisal::Appraisal, :name => "rails-7", :gemfile_path => "gemfiles/rails-7.gemfile")
+      end
+      let(:second_appraisal) do
+        instance_double(Appraisal::Appraisal, :name => "rails-8", :gemfile_path => "gemfiles/rails-8.gemfile")
+      end
+
+      it "runs the external command across appraisals with APPRAISAL_JOBS workers" do
+        first_command = instance_double(Appraisal::Command, :run => true)
+        second_command = instance_double(Appraisal::Command, :run => true)
+
+        stub_env("APPRAISAL_JOBS" => "2")
+        stub_const("ARGV", ["rake", "test"])
+        allow(appraisal_file).to receive(:appraisals).and_return([first_appraisal, second_appraisal])
+        allow(Appraisal::Command).to receive(:new)
+          .with(["rake", "test"], :gemfile => "gemfiles/rails-7.gemfile")
+          .and_return(first_command)
+        allow(Appraisal::Command).to receive(:new)
+          .with(["rake", "test"], :gemfile => "gemfiles/rails-8.gemfile")
+          .and_return(second_command)
+
+        expect(cli).to receive(:each_appraisal).with([first_appraisal, second_appraisal], "2").and_call_original
+
+        cli.send(:method_missing, :rake, "test")
+
+        expect(first_command).to have_received(:run)
+        expect(second_command).to have_received(:run)
+      end
+    end
   end
 
   describe "parse_external_options" do
@@ -203,6 +310,21 @@ RSpec.describe Appraisal::CLI do
 
     it "parses -j option" do
       result = cli.send(:parse_external_options, ["-j4"])
+      expect(result).to eq(:jobs => 4)
+    end
+
+    it "consumes --appraisal-jobs without forwarding it to dependency commands" do
+      result = cli.send(:parse_external_options, ["--appraisal-jobs=2"])
+      expect(result).to eq({})
+    end
+
+    it "consumes -n without forwarding it to dependency commands" do
+      result = cli.send(:parse_external_options, ["-n", "2", "--jobs=4"])
+      expect(result).to eq(:jobs => 4)
+    end
+
+    it "consumes --appraisal-jobs with a separate value" do
+      result = cli.send(:parse_external_options, ["--appraisal-jobs", "2", "--jobs=4"])
       expect(result).to eq(:jobs => 4)
     end
 
@@ -235,6 +357,12 @@ RSpec.describe Appraisal::CLI do
       gems, options = cli.send(:extract_gems_and_options, ["rails", "-g", "ore"])
       expect(gems).to eq(["rails"])
       expect(options).to eq(:gem_manager => "ore")
+    end
+
+    it "does not treat appraisal job values as gem names" do
+      gems, options = cli.send(:extract_gems_and_options, ["rails", "-n", "2"])
+      expect(gems).to eq(["rails"])
+      expect(options).to eq({})
     end
 
     it "handles repeated values correctly (reproducibility test)" do

--- a/spec/appraisal/command_spec.rb
+++ b/spec/appraisal/command_spec.rb
@@ -188,8 +188,31 @@ RSpec.describe Appraisal::Command do
 
           expect(locked_command).to have_received(:system)
             .with(hash_including("GEM_HOME" => gem_home), a_string_matching(/ruby --disable=gems .*bundler/m))
-            .twice
+            .once
         end
+      end
+    end
+
+    context "when the Bundler executable can boot" do
+      it "does not install bundler when RubyGems spec discovery is too narrow" do
+        allow(command).to receive(:system)
+          .with(anything, "bundle -v > /dev/null 2>&1")
+          .and_return(true)
+        allow(command).to receive(:system)
+          .with(anything, a_string_matching(/Gem::Specification\.find_all_by_name/))
+          .and_return(false)
+        allow(command).to receive(:system)
+          .with(anything, a_string_matching(/gem install bundler/))
+          .and_return(true)
+
+        command.run
+
+        expect(command).to have_received(:system)
+          .with(anything, "bundle -v > /dev/null 2>&1")
+        expect(command).not_to have_received(:system)
+          .with(anything, a_string_matching(/Gem::Specification\.find_all_by_name/))
+        expect(command).not_to have_received(:system)
+          .with(anything, a_string_matching(/gem install bundler/))
       end
     end
   end

--- a/spec/appraisal/command_spec.rb
+++ b/spec/appraisal/command_spec.rb
@@ -62,20 +62,22 @@ RSpec.describe Appraisal::Command do
     end
 
     context "with default settings" do
-      it "wraps execution in with_bundler_env and ensures bundler is available" do
-        allow(command).to receive(:with_bundler_env).and_yield
+      it "builds an isolated Bundler environment and ensures bundler is available" do
+        allow(command).to receive(:bundler_env).and_return({})
         allow(command).to receive(:ensure_bundler_is_available)
+        allow(command).to receive(:ensure_locked_bundler_is_available)
 
         command.run
 
-        expect(command).to have_received(:with_bundler_env)
-        expect(command).to have_received(:ensure_bundler_is_available)
+        expect(command).to have_received(:bundler_env).with(hash_including("GEM_PATH" => ENV["APPRAISAL_TEST_SYSTEM_GEM_PATH"].to_s))
+        expect(command).to have_received(:ensure_bundler_is_available).with({})
+        expect(command).to have_received(:ensure_locked_bundler_is_available).with({})
       end
     end
 
     context "with BUNDLE_PATH set in environment" do
       it "preserves BUNDLE_PATH and strips bundler activation markers" do
-        # This example exercises real ENV mutation inside Command#with_bundler_env.
+        # This example exercises the real environment builder used by Command#run.
         # rubocop:disable Env/Assign
         original_bundle_path = ENV["BUNDLE_PATH"]
         original_rubyopt = ENV["RUBYOPT"]
@@ -87,13 +89,14 @@ RSpec.describe Appraisal::Command do
           ENV["BUNDLER_SETUP"] = "1"
           ENV["BUNDLER_VERSION"] = "4.0.3"
 
-          allow(Bundler).to receive(:original_env).and_return({})
+          allow(Bundler).to receive(:unbundled_env).and_return({})
 
-          expect(Kernel).to receive(:system) do
-            expect(ENV["BUNDLE_PATH"]).to eq("/custom/path")
-            expect(ENV["BUNDLER_SETUP"]).to be_nil
-            expect(ENV["BUNDLER_VERSION"]).to be_nil
-            expect(ENV["RUBYOPT"]).to eq("-W0")
+          expect(Kernel).to receive(:system) do |env, _command|
+            expect(env["BUNDLE_PATH"]).to eq("/custom/path")
+            expect(env["BUNDLER_SETUP"]).to be_nil
+            expect(env["BUNDLE_VERSION"]).to be_nil
+            expect(env["BUNDLER_VERSION"]).to be_nil
+            expect(env["RUBYOPT"]).to eq("-W0")
             true
           end
 
@@ -105,6 +108,42 @@ RSpec.describe Appraisal::Command do
           ENV["BUNDLER_VERSION"] = original_bundler_version
         end
         # rubocop:enable Env/Assign
+      end
+    end
+
+    context "when Bundler environment helpers are available" do
+      it "uses unbundled_env instead of original_env as the subprocess base" do
+        allow(Bundler).to receive_messages(
+          :unbundled_env => {"PATH" => "/original/bin"},
+          :original_env => {"BUNDLE_FOO" => "leaked", "PATH" => "/original/bin"}
+        )
+
+        expect(Kernel).to receive(:system) do |env, _command|
+          expect(env["BUNDLE_FOO"]).to be_nil
+          true
+        end
+
+        command.run
+
+        expect(Bundler).to have_received(:unbundled_env)
+        expect(Bundler).not_to have_received(:original_env)
+      end
+    end
+
+    context "with an acceptance test Bundler version" do
+      it "pins the subprocess to the harness-selected Bundler version" do
+        harness_command = described_class.new(command_string, :gemfile => gemfile, :env => {"APPRAISAL_TEST_BUNDLER_VERSION" => "4.0.16"})
+        allow(harness_command).to receive(:system).and_return(true)
+        allow(harness_command).to receive(:puts)
+        allow(Bundler).to receive(:unbundled_env).and_return({})
+
+        expect(Kernel).to receive(:system) do |env, _command|
+          expect(env["BUNDLE_VERSION"]).to eq("4.0.16")
+          expect(env["BUNDLER_VERSION"]).to eq("4.0.16")
+          true
+        end
+
+        harness_command.run
       end
     end
 
@@ -132,27 +171,24 @@ RSpec.describe Appraisal::Command do
           locked_command = described_class.new(command_string, :gemfile => gemfile, :env => {"GEM_HOME" => gem_home, "GEM_PATH" => ""})
           allow(locked_command).to receive(:system).and_return(true)
           allow(locked_command).to receive(:puts)
-          allow(Bundler).to receive(:original_env).and_return({})
+          allow(Bundler).to receive(:unbundled_env).and_return({})
 
-          allow(locked_command).to receive(:system).with(%(gem list --silent -i bundler)) do
-            expect(ENV["GEM_HOME"]).to eq(gem_home)
-            true
-          end
-          allow(locked_command).to receive(:system).with(%(gem list --silent -i bundler -v "4.0.5")) do
-            expect(ENV["GEM_HOME"]).to eq(gem_home)
-            true
-          end
-          expect(Kernel).to receive(:system) do
-            expect(ENV["BUNDLE_GEMFILE"]).to eq(gemfile)
-            expect(ENV["BUNDLER_VERSION"]).to eq("4.0.5")
-            expect(ENV["BUNDLE_BIN_PATH"]).to be_nil
+          allow(locked_command).to receive(:system)
+            .with(hash_including("GEM_HOME" => gem_home), a_string_matching(/ruby --disable=gems .*bundler/m))
+            .and_return(true)
+          expect(Kernel).to receive(:system) do |env, _command|
+            expect(env["BUNDLE_GEMFILE"]).to eq(gemfile)
+            expect(env["BUNDLE_VERSION"]).to eq("4.0.5")
+            expect(env["BUNDLER_VERSION"]).to eq("4.0.5")
+            expect(env["BUNDLE_BIN_PATH"]).to be_nil
             true
           end
 
           locked_command.run
 
-          expect(locked_command).to have_received(:system).with(%(gem list --silent -i bundler))
-          expect(locked_command).to have_received(:system).with(%(gem list --silent -i bundler -v "4.0.5"))
+          expect(locked_command).to have_received(:system)
+            .with(hash_including("GEM_HOME" => gem_home), a_string_matching(/ruby --disable=gems .*bundler/m))
+            .twice
         end
       end
     end

--- a/spec/appraisal/gem_manager/bundler_adapter_spec.rb
+++ b/spec/appraisal/gem_manager/bundler_adapter_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Appraisal::GemManager::BundlerAdapter do
 
       expect(Appraisal::Command).to have_received(:new).with(
         "bundle check --gemfile='#{gemfile_path}' || bundle install --gemfile='#{gemfile_path}'",
+        :env => {"BUNDLE_JOBS" => "1"},
         :gemfile => gemfile_path
       )
     end
@@ -52,6 +53,7 @@ RSpec.describe Appraisal::GemManager::BundlerAdapter do
 
           expect(Appraisal::Command).to have_received(:new).with(
             "bundle check --gemfile='#{gemfile_path}' || bundle install --gemfile='#{gemfile_path}' --jobs=4",
+            :env => {"BUNDLE_JOBS" => "4"},
             :gemfile => gemfile_path
           )
         end
@@ -71,6 +73,7 @@ RSpec.describe Appraisal::GemManager::BundlerAdapter do
 
           expect(Appraisal::Command).to have_received(:new).with(
             "bundle check --gemfile='#{gemfile_path}' || bundle install --gemfile='#{gemfile_path}'",
+            :env => {"BUNDLE_JOBS" => "1"},
             :gemfile => gemfile_path
           )
           expect(warning).to include("Please upgrade Bundler")
@@ -82,6 +85,7 @@ RSpec.describe Appraisal::GemManager::BundlerAdapter do
 
         expect(Appraisal::Command).to have_received(:new).with(
           "bundle check --gemfile='#{gemfile_path}' || bundle install --gemfile='#{gemfile_path}'",
+          :env => {"BUNDLE_JOBS" => "1"},
           :gemfile => gemfile_path
         )
       end
@@ -93,6 +97,7 @@ RSpec.describe Appraisal::GemManager::BundlerAdapter do
 
         expect(Appraisal::Command).to have_received(:new).with(
           "bundle check --gemfile='#{gemfile_path}' || bundle install --gemfile='#{gemfile_path}' --retry 3",
+          :env => {"BUNDLE_JOBS" => "1"},
           :gemfile => gemfile_path
         )
       end
@@ -105,6 +110,7 @@ RSpec.describe Appraisal::GemManager::BundlerAdapter do
         expect(Appraisal::Command).to have_received(:new).with(
           "bundle config set --local path /home/test/vendor/bundle && " \
             "(bundle check --gemfile='#{gemfile_path}' || bundle install --gemfile='#{gemfile_path}')",
+          :env => {"BUNDLE_JOBS" => "1"},
           :gemfile => gemfile_path
         )
       end
@@ -116,6 +122,7 @@ RSpec.describe Appraisal::GemManager::BundlerAdapter do
 
         expect(Appraisal::Command).to have_received(:new).with(
           "bundle install --gemfile='#{gemfile_path}' --without development test",
+          :env => {"BUNDLE_JOBS" => "1"},
           :gemfile => gemfile_path
         )
       end
@@ -131,7 +138,7 @@ RSpec.describe Appraisal::GemManager::BundlerAdapter do
 
         expect(Appraisal::Command).to have_received(:new).with(
           "bundle check --gemfile='#{gemfile_path}' || bundle install --gemfile='#{gemfile_path}'",
-          :env => {"BUNDLE_DISABLE_SHARED_GEMS" => "1"},
+          :env => {"BUNDLE_DISABLE_SHARED_GEMS" => "1", "BUNDLE_JOBS" => "1"},
           :gemfile => gemfile_path
         )
       end

--- a/spec/support/acceptance_test_helpers.rb
+++ b/spec/support/acceptance_test_helpers.rb
@@ -338,11 +338,21 @@ module AcceptanceTestHelpers
   APPRAISAL2_GEM_PATH = "./appraisal2"
 
   def test_bundler_version
+    return loaded_bundler_version if RUBY_ENGINE == "truffleruby" && loaded_bundler_version
+
     # Use an installed Bundler spec, not Bundler::VERSION from the current
     # process. Local Rubies can have an older Bundler library already loaded
     # while a newer Bundler spec is installed, and subprocesses need a version
     # RubyGems can activate consistently.
     Gem::Specification.find_all_by_name("bundler").map(&:version).max.to_s
+  end
+
+  def loaded_bundler_version
+    loaded_spec = Gem.loaded_specs["bundler"]
+    spec_version = loaded_spec.version if loaded_spec
+    return spec_version.to_s if spec_version
+
+    defined?(Bundler::VERSION) ? Bundler::VERSION.to_s : nil
   end
 
   def install_test_binstub_gem_path_prelude(bin_path)

--- a/spec/support/acceptance_test_helpers.rb
+++ b/spec/support/acceptance_test_helpers.rb
@@ -4,6 +4,7 @@
 require "rspec/expectations/expectation_target"
 require "active_support/core_ext/string/filters"
 require "active_support/concern"
+require "rbconfig"
 require "shellwords"
 
 # This library
@@ -338,7 +339,10 @@ module AcceptanceTestHelpers
   APPRAISAL2_GEM_PATH = "./appraisal2"
 
   def test_bundler_version
-    return loaded_bundler_version if RUBY_ENGINE == "truffleruby" && loaded_bundler_version
+    if RUBY_ENGINE == "truffleruby"
+      version = ruby_shipped_bundler_version
+      return version if version
+    end
 
     # Use an installed Bundler spec, not Bundler::VERSION from the current
     # process. Local Rubies can have an older Bundler library already loaded
@@ -347,10 +351,16 @@ module AcceptanceTestHelpers
     Gem::Specification.find_all_by_name("bundler").map(&:version).max.to_s
   end
 
+  def ruby_shipped_bundler_version
+    output = IO.popen(rubygems_command_env, [RbConfig.ruby, "--disable-gems", "-rbundler/version", "-e", "puts Bundler::VERSION"], &:read)
+    version = output.to_s.strip
+    version unless version.empty?
+  rescue Errno::ENOENT, LoadError
+    nil
+  end
+
   def loaded_bundler_version
-    loaded_spec = Gem.loaded_specs["bundler"]
-    spec_version = loaded_spec.version if loaded_spec
-    return spec_version.to_s if spec_version
+    return Gem.loaded_specs["bundler"].version.to_s if Gem.loaded_specs["bundler"]
 
     defined?(Bundler::VERSION) ? Bundler::VERSION.to_s : nil
   end

--- a/spec/support/acceptance_test_helpers.rb
+++ b/spec/support/acceptance_test_helpers.rb
@@ -371,6 +371,19 @@ module AcceptanceTestHelpers
       next if File.basename(binstub) == "bundle"
 
       contents = File.read(binstub)
+      unless contents.include?("APPRAISAL_TEST_BUNDLER_VERSION")
+        contents.sub!(
+          "require \"pathname\"\n",
+          <<-RUBY.strip_heredoc
+            if ENV["APPRAISAL_TEST_BUNDLER_VERSION"] && !ENV["APPRAISAL_TEST_BUNDLER_VERSION"].empty?
+              ENV["BUNDLE_VERSION"] = ENV["APPRAISAL_TEST_BUNDLER_VERSION"]
+              ENV["BUNDLER_VERSION"] = ENV["APPRAISAL_TEST_BUNDLER_VERSION"]
+            end
+            require "pathname"
+          RUBY
+        )
+      end
+
       next if contents.include?("APPRAISAL_TEST_SYSTEM_GEM_PATH")
 
       contents.sub!(

--- a/spec/support/acceptance_test_helpers.rb
+++ b/spec/support/acceptance_test_helpers.rb
@@ -4,6 +4,7 @@
 require "rspec/expectations/expectation_target"
 require "active_support/core_ext/string/filters"
 require "active_support/concern"
+require "shellwords"
 
 # This library
 require "appraisal/utils"
@@ -19,6 +20,7 @@ module AcceptanceTestHelpers
     "BUNDLER_VERSION",
     "BUNDLE_GEMFILE",
     "BUNDLE_LOCKFILE",
+    "BUNDLE_VERSION",
     "BUNDLER_SETUP",
     "BUNDLE_APP_CONFIG",
     "BUNDLE_USER_CONFIG",
@@ -261,20 +263,32 @@ module AcceptanceTestHelpers
   end
 
   def ensure_bundler_is_available
-    return if in_test_directory { system("bundle -v > /dev/null 2>&1") }
+    clean_env = rubygems_command_env
 
-    # Check if any version of bundler is already installed
-    check_cmd = "gem list --silent -i bundler"
-    begin
-      return if run("#{check_cmd} 2>&1", false).include?("true")
-    rescue
-      nil
-    end
+    return if in_test_directory { system(clean_env, "bundle -v > /dev/null 2>&1") }
+
+    return if in_test_directory { system(clean_env, bundler_available_command) }
 
     puts ">> Bundler not found in #{TMP_GEM_ROOT}, attempting to install..."
 
-    # Try to install the latest stable version
-    run "gem install bundler --install-dir '#{TMP_GEM_ROOT}'"
+    return if in_test_directory { system(clean_env, "gem install bundler --install-dir '#{TMP_GEM_ROOT}'") }
+
+    raise "Bundler installation failed in #{TMP_GEM_ROOT}"
+  end
+
+  def rubygems_command_env
+    ENV.to_h.tap do |env|
+      BUNDLER_ENVIRONMENT_VARIABLES.each { |key| env[key] = nil }
+    end
+  end
+
+  def bundler_available_command
+    code = <<-RUBY.chomp
+      require "rubygems"
+      specs = Gem::Specification.find_all_by_name("bundler")
+      exit(specs.empty? ? 1 : 0)
+    RUBY
+    "ruby --disable=gems -e #{Shellwords.escape(code)}"
   end
 
   def build_default_gemfile
@@ -284,6 +298,7 @@ module AcceptanceTestHelpers
     build_gemfile <<-GEMFILE.strip_heredoc.rstrip
       source 'https://gem.coop'
 
+      gem 'bundler', '#{test_bundler_version}'
       gem 'appraisal2', :path => './appraisal2'
     GEMFILE
 
@@ -323,11 +338,11 @@ module AcceptanceTestHelpers
   APPRAISAL2_GEM_PATH = "./appraisal2"
 
   def test_bundler_version
-    if defined?(Bundler::VERSION)
-      Bundler::VERSION
-    else
-      Gem.loaded_specs.fetch("bundler").version.to_s
-    end
+    # Use an installed Bundler spec, not Bundler::VERSION from the current
+    # process. Local Rubies can have an older Bundler library already loaded
+    # while a newer Bundler spec is installed, and subprocesses need a version
+    # RubyGems can activate consistently.
+    Gem::Specification.find_all_by_name("bundler").map(&:version).max.to_s
   end
 
   def install_test_binstub_gem_path_prelude(bin_path)

--- a/spec/support/acceptance_test_helpers_spec.rb
+++ b/spec/support/acceptance_test_helpers_spec.rb
@@ -14,4 +14,26 @@ RSpec.describe AcceptanceTestHelpers do
       expect(ENV["GEM_HOME"]).to eq("/original/gem/home")
     end
   end
+
+  describe "#test_bundler_version" do
+    it "uses the loaded Bundler on TruffleRuby instead of the newest installed spec" do
+      stub_const("RUBY_ENGINE", "truffleruby")
+      allow(self).to receive(:loaded_bundler_version).and_return("2.2.32")
+
+      newer_spec = instance_double(Gem::Specification, :version => Gem::Version.new("2.5.23"))
+      allow(Gem::Specification).to receive(:find_all_by_name).with("bundler").and_return([newer_spec])
+
+      expect(test_bundler_version).to eq("2.2.32")
+    end
+
+    it "uses the newest installed Bundler spec on other engines" do
+      stub_const("RUBY_ENGINE", "ruby")
+
+      older_spec = instance_double(Gem::Specification, :version => Gem::Version.new("2.4.0"))
+      newer_spec = instance_double(Gem::Specification, :version => Gem::Version.new("2.5.0"))
+      allow(Gem::Specification).to receive(:find_all_by_name).with("bundler").and_return([older_spec, newer_spec])
+
+      expect(test_bundler_version).to eq("2.5.0")
+    end
+  end
 end

--- a/spec/support/acceptance_test_helpers_spec.rb
+++ b/spec/support/acceptance_test_helpers_spec.rb
@@ -1,7 +1,37 @@
 # frozen_string_literal: true
 
+require "tmpdir"
+
 RSpec.describe AcceptanceTestHelpers do
   include described_class
+
+  describe "#install_test_binstub_gem_path_prelude" do
+    it "pins generated test binstubs to the harness-selected Bundler version" do
+      FileUtils.mkdir_p(File.join(Dir.pwd, "tmp"))
+
+      Dir.mktmpdir("binstub", File.join(Dir.pwd, "tmp")) do |dir|
+        binstub = File.join(dir, "appraisal")
+        File.write(binstub, <<-RUBY.strip_heredoc)
+          #!/usr/bin/env ruby
+          require "pathname"
+          bundle_binstub = File.expand_path("../bundle", __FILE__)
+          load(bundle_binstub)
+          require "rubygems"
+          require "bundler/setup"
+          load Gem.bin_path("appraisal2", "appraisal")
+        RUBY
+
+        install_test_binstub_gem_path_prelude(dir)
+
+        contents = File.read(binstub)
+        bundler_pin_index = contents.index('ENV["BUNDLER_VERSION"] = ENV["APPRAISAL_TEST_BUNDLER_VERSION"]')
+        bundle_binstub_load_index = contents.index("load(bundle_binstub)")
+
+        expect(contents).to include('ENV["BUNDLE_VERSION"] = ENV["APPRAISAL_TEST_BUNDLER_VERSION"]')
+        expect(bundler_pin_index).to be < bundle_binstub_load_index
+      end
+    end
+  end
 
   describe "#restore_environment_variables" do
     it "restores GEM_HOME after fixture gem setup changes it" do

--- a/spec/support/acceptance_test_helpers_spec.rb
+++ b/spec/support/acceptance_test_helpers_spec.rb
@@ -16,14 +16,24 @@ RSpec.describe AcceptanceTestHelpers do
   end
 
   describe "#test_bundler_version" do
-    it "uses the loaded Bundler on TruffleRuby instead of the newest installed spec" do
+    it "uses the Ruby-shipped Bundler on TruffleRuby instead of the newest installed spec" do
       stub_const("RUBY_ENGINE", "truffleruby")
-      allow(self).to receive(:loaded_bundler_version).and_return("2.2.32")
+      allow(self).to receive(:ruby_shipped_bundler_version).and_return("2.2.32")
 
       newer_spec = instance_double(Gem::Specification, :version => Gem::Version.new("2.5.23"))
       allow(Gem::Specification).to receive(:find_all_by_name).with("bundler").and_return([newer_spec])
 
       expect(test_bundler_version).to eq("2.2.32")
+    end
+
+    it "falls back to the newest installed Bundler spec on TruffleRuby when the shipped version cannot be detected" do
+      stub_const("RUBY_ENGINE", "truffleruby")
+      allow(self).to receive(:ruby_shipped_bundler_version).and_return(nil)
+
+      newer_spec = instance_double(Gem::Specification, :version => Gem::Version.new("2.5.23"))
+      allow(Gem::Specification).to receive(:find_all_by_name).with("bundler").and_return([newer_spec])
+
+      expect(test_bundler_version).to eq("2.5.23")
     end
 
     it "uses the newest installed Bundler spec on other engines" do


### PR DESCRIPTION
## Summary

- parallelize appraisal-level `install`, `update`, `generate-install`, `generate-update`, and external command fan-out with `--jobs` / `APPRAISAL_JOBS`
- make `Appraisal::Command` pass isolated env hashes to subprocesses instead of mutating global `ENV`, so parallel workers do not race on Bundler state
- harden acceptance-test Bundler bootstrap against inherited Bundler env and remote Bundler version drift

## Verification

- `bundle exec kettle-test spec/appraisal/cli_spec.rb spec/appraisal/command_spec.rb`
- `bundle exec kettle-test spec/acceptance/cli/install_spec.rb:10`
- `bundle exec kettle-test spec/acceptance/cli/install_spec.rb spec/acceptance/cli/named_appraisal_install_spec.rb`
- `bundle exec kettle-test spec/acceptance/cli/update_spec.rb spec/acceptance/cli/named_appraisal_update_spec.rb spec/acceptance/cli/run_spec.rb`
- `bin/rake rubocop_gradual:autocorrect`
- `bundle exec kettle-test`