### PR TITLE
Cache acceptance fixtures per worker

### DIFF
--- a/.github/workflows/jruby-10.0.yml
+++ b/.github/workflows/jruby-10.0.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/jruby-9.2.yml
+++ b/.github/workflows/jruby-9.2.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/jruby-9.3.yml
+++ b/.github/workflows/jruby-9.3.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/jruby-9.4.yml
+++ b/.github/workflows/jruby-9.4.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'jruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/truffle.yml
+++ b/.github/workflows/truffle.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/truffleruby-22.3.yml
+++ b/.github/workflows/truffleruby-22.3.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/truffleruby-23.0.yml
+++ b/.github/workflows/truffleruby-23.0.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/truffleruby-23.1.yml
+++ b/.github/workflows/truffleruby-23.1.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/truffleruby-24.2.yml
+++ b/.github/workflows/truffleruby-24.2.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/truffleruby-25.0.yml
+++ b/.github/workflows/truffleruby-25.0.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/.github/workflows/truffleruby-33.0.yml
+++ b/.github/workflows/truffleruby-33.0.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   test:
-    if: "github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
+    if: "(github.event_name != 'push' || (!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]'))) && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'engines/') || startsWith(github.head_ref, 'truffleruby/'))"
     name: Specs ${{ matrix.ruby }}@${{ matrix.appraisal }}
     runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental || endsWith(matrix.ruby, 'head') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Please file a bug if you notice a violation of semantic versioning.
 
 - Full dependency updates now run `bundle update --all` to avoid Bundler's
   deprecated implicit full-update form.
+- Acceptance specs now opt into expensive dummy-gem and bundle fixture setup
+  through metadata, and reuse a per-worker cached default fixture stage.
 - `generate-install` and `generate-update` now reuse the parsed Appraisals set
   for their generate and install/update phases.
 
@@ -54,6 +56,8 @@ Please file a bug if you notice a violation of semantic versioning.
 - Bundler-backed appraisal installs now set `BUNDLE_JOBS` explicitly so the
   configured Appraisal job count also controls Bundler's installer worker
   count in subprocesses.
+- JRuby and TruffleRuby workflows now correctly skip ordinary pull request
+  branches unless the branch targets `jruby/`, `truffleruby/`, or `engines/`.
 
 ### Security
 

--- a/spec/config/rspec/rspec_core.rb
+++ b/spec/config/rspec/rspec_core.rb
@@ -6,6 +6,10 @@ TMP_GEM_ROOT = File.join(TMP_PROCESS_ROOT, "bundler")
 puts "Using tmp gem root: #{TMP_GEM_ROOT}"
 TMP_GEM_BUILD = File.join(TMP_PROCESS_ROOT, "build")
 puts "Using tmp gem build: #{TMP_GEM_BUILD}"
+TMP_FIXTURE_ROOT = File.join(TMP_PROCESS_ROOT, "fixtures")
+puts "Using tmp fixture root: #{TMP_FIXTURE_ROOT}"
+TMP_DEFAULT_STAGE_TEMPLATE = File.join(TMP_FIXTURE_ROOT, "default-stage")
+puts "Using tmp default stage template: #{TMP_DEFAULT_STAGE_TEMPLATE}"
 TMP_STAGE_ROOT = File.join(TMP_PROCESS_ROOT, "stage")
 puts "Using tmp stage root: #{TMP_STAGE_ROOT}"
 ENV["APPRAISAL_UNDER_TEST"] = "1"
@@ -25,6 +29,8 @@ RSpec.configure do |config|
 
   config.define_derived_metadata(:file_path => %r{spec/acceptance/}) do |metadata|
     metadata[:type] = :acceptance
+    metadata[:appraisal_fixture] = true unless metadata.key?(:appraisal_fixture)
+    metadata[:dummy_gems] = true unless metadata.key?(:dummy_gems)
   end
 
   config.before :suite do

--- a/spec/support/acceptance_test_helpers.rb
+++ b/spec/support/acceptance_test_helpers.rb
@@ -29,6 +29,20 @@ module AcceptanceTestHelpers
     "BUNDLE_USER_PLUGIN"
   ].freeze
 
+  ACCEPTANCE_ENVIRONMENT_VARIABLES = (BUNDLER_ENVIRONMENT_VARIABLES + [
+    "PATH",
+    "HOME",
+    "GEM_HOME",
+    "BUNDLE_IGNORE_FUNDING_REQUESTS",
+    "BUNDLE_DISABLE_SHARED_GEMS",
+    "GEM_PATH",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_KEY_0",
+    "GIT_CONFIG_VALUE_0",
+    "APPRAISAL_TEST_BUNDLER_VERSION",
+    "APPRAISAL_TEST_SYSTEM_GEM_PATH"
+  ]).freeze
+
   included do
     metadata[:type] = :acceptance
 
@@ -48,15 +62,12 @@ module AcceptanceTestHelpers
       skip "ore-light not installed" unless ore_available?
     end
 
-    before do
+    before do |example|
       cleanup_artifacts
       save_environment_variables
       unset_bundler_environment_variables
       setup_isolated_bundler_environment
-      build_default_dummy_gems
-      ensure_bundler_is_available
-      add_binstub_path
-      build_default_gemfile
+      setup_acceptance_fixture(example.metadata)
     end
 
     after do
@@ -76,22 +87,7 @@ module AcceptanceTestHelpers
   def save_environment_variables
     @original_environment_variables = {}
 
-    # Save all bundler variables plus PATH and the isolation variables we set
-    vars_to_save = BUNDLER_ENVIRONMENT_VARIABLES + [
-      "PATH",
-      "HOME",
-      "GEM_HOME",
-      "BUNDLE_IGNORE_FUNDING_REQUESTS",
-      "BUNDLE_DISABLE_SHARED_GEMS",
-      "GEM_PATH",
-      "GIT_CONFIG_COUNT",
-      "GIT_CONFIG_KEY_0",
-      "GIT_CONFIG_VALUE_0",
-      "APPRAISAL_TEST_BUNDLER_VERSION",
-      "APPRAISAL_TEST_SYSTEM_GEM_PATH"
-    ]
-
-    vars_to_save.each do |key|
+    ACCEPTANCE_ENVIRONMENT_VARIABLES.each do |key|
       @original_environment_variables[key] = ENV[key]
     end
   end
@@ -245,7 +241,7 @@ module AcceptanceTestHelpers
   private
 
   def current_directory
-    TMP_STAGE_ROOT
+    @current_directory || TMP_STAGE_ROOT
   end
 
   def write_file(filename, content)
@@ -254,6 +250,57 @@ module AcceptanceTestHelpers
 
   def cleanup_artifacts
     FileUtils.rm_rf current_directory
+  end
+
+  def setup_acceptance_fixture(metadata)
+    build_default_dummy_gems if metadata[:dummy_gems]
+
+    if metadata[:appraisal_fixture]
+      copy_default_stage_template
+      add_binstub_path
+    elsif metadata[:binstub_path]
+      add_binstub_path
+    end
+  end
+
+  def copy_default_stage_template
+    ensure_default_stage_template
+    FileUtils.cp_r("#{TMP_DEFAULT_STAGE_TEMPLATE}/.", current_directory)
+  end
+
+  def ensure_default_stage_template
+    ready_file = File.join(TMP_DEFAULT_STAGE_TEMPLATE, ".appraisal-fixture-ready")
+    return if File.exist?(ready_file)
+
+    FileUtils.rm_rf TMP_DEFAULT_STAGE_TEMPLATE
+    FileUtils.mkdir_p TMP_DEFAULT_STAGE_TEMPLATE
+
+    with_current_directory(TMP_DEFAULT_STAGE_TEMPLATE) do
+      with_bundle_environment_for_current_directory do
+        ensure_bundler_is_available
+        add_binstub_path
+        build_default_gemfile
+      end
+    end
+
+    FileUtils.touch(ready_file)
+  end
+
+  def with_current_directory(path)
+    previous_directory = @current_directory
+    @current_directory = path
+    yield
+  ensure
+    @current_directory = previous_directory
+  end
+
+  def with_bundle_environment_for_current_directory
+    saved_environment = ACCEPTANCE_ENVIRONMENT_VARIABLES.each_with_object({}) { |key, env| env[key] = ENV[key] }
+
+    setup_isolated_bundler_environment
+    yield
+  ensure
+    saved_environment.each_pair { |key, value| ENV[key] = value }
   end
 
   def build_default_dummy_gems

--- a/spec/support/acceptance_test_helpers_spec.rb
+++ b/spec/support/acceptance_test_helpers_spec.rb
@@ -2,8 +2,34 @@
 
 require "tmpdir"
 
-RSpec.describe AcceptanceTestHelpers do
+RSpec.describe AcceptanceTestHelpers, :appraisal_fixture => false, :dummy_gems => false do
   include described_class
+
+  describe "#setup_acceptance_fixture" do
+    it "does not prepare dummy gems or bundle fixtures without opt-in metadata" do
+      allow(self).to receive(:build_default_dummy_gems)
+      allow(self).to receive(:copy_default_stage_template)
+      allow(self).to receive(:add_binstub_path)
+
+      send(:setup_acceptance_fixture, {})
+
+      expect(self).not_to have_received(:build_default_dummy_gems)
+      expect(self).not_to have_received(:copy_default_stage_template)
+      expect(self).not_to have_received(:add_binstub_path)
+    end
+
+    it "prepares the cached bundle fixture and dummy gems when metadata opts in" do
+      allow(self).to receive(:build_default_dummy_gems)
+      allow(self).to receive(:copy_default_stage_template)
+      allow(self).to receive(:add_binstub_path)
+
+      send(:setup_acceptance_fixture, {:appraisal_fixture => true, :dummy_gems => true})
+
+      expect(self).to have_received(:build_default_dummy_gems)
+      expect(self).to have_received(:copy_default_stage_template)
+      expect(self).to have_received(:add_binstub_path)
+    end
+  end
 
   describe "#install_test_binstub_gem_path_prelude" do
     it "pins generated test binstubs to the harness-selected Bundler version" do


### PR DESCRIPTION
## Summary
- add metadata gates for acceptance dummy-gem and bundle fixture setup
- cache the default isolated appraisal fixture once per worker and copy it into each example stage
- fix JRuby/TruffleRuby workflow guards so ordinary PR branches do not run engine jobs

## Investigation
The JRuby jobs ran on PR #47 because the generated job condition began with an ungrouped push-event check. For pull request events that first clause is true, so the branch guard later in the expression did not restrict the job. The corrected condition groups the push skip-check separately before applying the PR branch filter.

The runtime cost was in the test step, not setup: MRI ran around 1-2 minutes, TruffleRuby 8-19 minutes, and JRuby 25-41 minutes for the same 43 spec files. The acceptance harness was rebuilding the same isolated fixture bundle for every acceptance example, which is especially expensive on non-MRI engines.

## Verification
- mise exec -C /home/pboling/src/my/appraisal-rb/appraisal2 -- env K_SOUP_COV_MIN_HARD=false bundle exec kettle-test spec/support/acceptance_test_helpers_spec.rb
- mise exec -C /home/pboling/src/my/appraisal-rb/appraisal2 -- env K_SOUP_COV_MIN_HARD=false bundle exec kettle-test spec/acceptance/cli/generate_spec.rb spec/acceptance/cli/version_spec.rb
- mise exec -C /home/pboling/src/my/appraisal-rb/appraisal2 -- bin/rake rubocop_gradual:autocorrect
- mise exec -C /home/pboling/src/my/appraisal-rb/appraisal2 -- bundle exec kettle-test