### PR TITLE
Use RSpec status timings for CI grouping

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,7 +48,7 @@ jobs:
           # Coverage
           - ruby: "ruby"
             appraisal: "coverage"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: latest
             bundler: latest
 

--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -39,7 +39,7 @@ jobs:
           # Ruby 4.0
           - ruby: "ruby"
             appraisal: "current"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: latest
             bundler: latest
 

--- a/.github/workflows/dep-heads.yml
+++ b/.github/workflows/dep-heads.yml
@@ -42,7 +42,7 @@ jobs:
           # Ruby 3.4
           - ruby: "ruby"
             appraisal: "dep-heads"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: latest
             bundler: latest
 
@@ -93,7 +93,7 @@ jobs:
         include:
           - ruby: "truffleruby"
             appraisal: "dep-heads"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             bundle_gemfile: "gemfiles/dep_heads.gemfile"
             direct_bundle: true
             rubygems: default
@@ -132,7 +132,7 @@ jobs:
         include:
           - ruby: "jruby"
             appraisal: "dep-heads"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
             experimental: true

--- a/.github/workflows/heads.yml
+++ b/.github/workflows/heads.yml
@@ -41,7 +41,7 @@ jobs:
           # ruby-head
           - ruby: "ruby-head"
             appraisal: "head"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
 
@@ -92,7 +92,7 @@ jobs:
         include:
           - ruby: "truffleruby-head"
             appraisal: "head"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
 
@@ -140,7 +140,7 @@ jobs:
         include:
           - ruby: "jruby-head"
             appraisal: "head"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
 

--- a/.github/workflows/jruby-10.0.yml
+++ b/.github/workflows/jruby-10.0.yml
@@ -39,7 +39,7 @@ jobs:
           # jruby-10.0 (targets Ruby 3.4 compatibility)
           - ruby: "jruby-10.0"
             appraisal: "ruby-3-4"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
             experimental: true

--- a/.github/workflows/jruby-9.2.yml
+++ b/.github/workflows/jruby-9.2.yml
@@ -39,7 +39,7 @@ jobs:
           # jruby-9.2 (targets Ruby 2.5 compatibility)
           - ruby: "jruby-9.2"
             appraisal: "ruby-2-5"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: 3.3.27
             bundler: 2.3.27
 

--- a/.github/workflows/jruby-9.3.yml
+++ b/.github/workflows/jruby-9.3.yml
@@ -39,7 +39,7 @@ jobs:
           # jruby-9.3 (targets Ruby 2.6 compatibility)
           - ruby: "jruby-9.3"
             appraisal: "ruby-2-6"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: "3.4.22"
             bundler: "2.4.22"
 

--- a/.github/workflows/jruby-9.4.yml
+++ b/.github/workflows/jruby-9.4.yml
@@ -39,7 +39,7 @@ jobs:
           # jruby-9.4 (targets Ruby 3.1 compatibility)
           - ruby: "jruby-9.4"
             appraisal: "ruby-3-1"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: "3.6.9"
             bundler: "2.6.9"
 

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -39,7 +39,7 @@ jobs:
           # jruby-10.1 (targets Ruby 4.0 compatibility)
           - ruby: "jruby"
             appraisal: "current"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
             experimental: true

--- a/.github/workflows/ruby-2.4.yml
+++ b/.github/workflows/ruby-2.4.yml
@@ -36,7 +36,7 @@ jobs:
           # Ruby 2.4
           - ruby: "ruby-2.4"
             appraisal: "ruby-2-4"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: "3.3.27"
             bundler: "2.3.27"
 

--- a/.github/workflows/ruby-2.5.yml
+++ b/.github/workflows/ruby-2.5.yml
@@ -36,7 +36,7 @@ jobs:
           # Ruby 2.5
           - ruby: "ruby-2.5"
             appraisal: "ruby-2-5"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: "3.3.27"
             bundler: "2.3.27"
 

--- a/.github/workflows/ruby-2.6.yml
+++ b/.github/workflows/ruby-2.6.yml
@@ -36,7 +36,7 @@ jobs:
           # Ruby 2.6
           - ruby: "ruby-2.6"
             appraisal: "ruby-2-6"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: '3.4.22'
             bundler: '2.4.22'
 

--- a/.github/workflows/ruby-2.7.yml
+++ b/.github/workflows/ruby-2.7.yml
@@ -36,7 +36,7 @@ jobs:
           # Ruby 2.7
           - ruby: "ruby-2.7"
             appraisal: "ruby-2-7"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: '3.4.22'
             bundler: '2.4.22'
 

--- a/.github/workflows/ruby-3.0.yml
+++ b/.github/workflows/ruby-3.0.yml
@@ -39,7 +39,7 @@ jobs:
           # Ruby 3.0
           - ruby: "ruby-3.0"
             appraisal: "ruby-3-0"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: '3.5.23'
             bundler: '2.5.23'
 

--- a/.github/workflows/ruby-3.1.yml
+++ b/.github/workflows/ruby-3.1.yml
@@ -39,7 +39,7 @@ jobs:
           # Ruby 3.1
           - ruby: "ruby-3.1"
             appraisal: "ruby-3-1"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: '3.6.9'
             bundler: '2.6.9'
 

--- a/.github/workflows/ruby-3.2.yml
+++ b/.github/workflows/ruby-3.2.yml
@@ -36,7 +36,7 @@ jobs:
           # Ruby 3.2
           - ruby: "ruby-3.2"
             appraisal: "ruby-3-2"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: latest
             bundler: latest
 

--- a/.github/workflows/ruby-3.3.yml
+++ b/.github/workflows/ruby-3.3.yml
@@ -36,7 +36,7 @@ jobs:
           # Ruby 3.3
           - ruby: "ruby-3.3"
             appraisal: "ruby-3-3"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: latest
             bundler: latest
 

--- a/.github/workflows/ruby-3.4.yml
+++ b/.github/workflows/ruby-3.4.yml
@@ -36,7 +36,7 @@ jobs:
           # Ruby 3.4
           - ruby: "ruby-3.4"
             appraisal: "ruby-3-4"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: latest
             bundler: latest
 

--- a/.github/workflows/truffle.yml
+++ b/.github/workflows/truffle.yml
@@ -40,7 +40,7 @@ jobs:
           # truffleruby-34.0 (targets Ruby 3.4 compatibility)
           - ruby: "truffleruby"
             appraisal: "current"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
 

--- a/.github/workflows/truffleruby-22.3.yml
+++ b/.github/workflows/truffleruby-22.3.yml
@@ -40,7 +40,7 @@ jobs:
           # truffleruby-22.3 (targets Ruby 3.0 compatibility)
           - ruby: "truffleruby-22.3"
             appraisal: "ruby-3-0"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
             experimental: true

--- a/.github/workflows/truffleruby-23.0.yml
+++ b/.github/workflows/truffleruby-23.0.yml
@@ -40,7 +40,7 @@ jobs:
           # truffleruby-23.0 (targets Ruby 3.0 compatibility)
           - ruby: "truffleruby-23.0"
             appraisal: "ruby-3-0"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
             experimental: true

--- a/.github/workflows/truffleruby-23.1.yml
+++ b/.github/workflows/truffleruby-23.1.yml
@@ -40,7 +40,7 @@ jobs:
           # truffleruby-23.1 (targets Ruby 3.2 compatibility)
           - ruby: "truffleruby-23.1"
             appraisal: "ruby-3-2"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
             experimental: true

--- a/.github/workflows/truffleruby-24.2.yml
+++ b/.github/workflows/truffleruby-24.2.yml
@@ -40,7 +40,7 @@ jobs:
           # truffleruby-24.2 (targets Ruby 3.3 compatibility)
           - ruby: "truffleruby-24.2"
             appraisal: "ruby-3-3"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
 

--- a/.github/workflows/truffleruby-25.0.yml
+++ b/.github/workflows/truffleruby-25.0.yml
@@ -40,7 +40,7 @@ jobs:
           # truffleruby-25.0 (targets Ruby 3.3 compatibility)
           - ruby: "truffleruby-25.0"
             appraisal: "ruby-3-3"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
 

--- a/.github/workflows/truffleruby-33.0.yml
+++ b/.github/workflows/truffleruby-33.0.yml
@@ -40,7 +40,7 @@ jobs:
           # truffleruby-33.0 (targets Ruby 3.3 compatibility)
           - ruby: "truffleruby-33.0"
             appraisal: "ruby-3-3"
-            exec_cmd: "kettle-test"
+            exec_cmd: "kettle-test --example-status-log .rspec_status"
             rubygems: default
             bundler: default
 

--- a/.structuredmerge/kettle-jem.yml
+++ b/.structuredmerge/kettle-jem.yml
@@ -152,7 +152,7 @@ repository:
 workflows:
   # Default command used by generated test workflows.
   # ENV override: KJ_EXEC_CMD
-  exec_cmd: kettle-test
+  exec_cmd: kettle-test --example-status-log .rspec_status
   # Include VCR/WebMock recording modular gemfiles in generated Appraisals.
   # Enable only for projects that actually require recording support.
   recording: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Please file a bug if you notice a violation of semantic versioning.
   deprecated implicit full-update form.
 - Acceptance specs now opt into expensive dummy-gem and bundle fixture setup
   through metadata, and reuse a per-worker cached default fixture stage.
+- Generated CI workflows now pass `.rspec_status` to `kettle-test` so
+  `turbo_tests2` can balance workers with historical example timings.
 - `generate-install` and `generate-update` now reuse the parsed Appraisals set
   for their generate and install/update phases.
 


### PR DESCRIPTION
## Summary

- pass `.rspec_status` through `kettle-test` in generated CI workflow commands
- keep `kettle-test` as the runner while allowing `turbo_tests2` to balance workers with historical example timings
- update the kettle-jem config so future templating preserves the workflow command

## CI timing review

After PR #48 landed on `main`, completed engine jobs improved materially:

- JRuby 9.3: ~12m, down from roughly ~26m before the fixture-cache work
- JRuby 9.2: ~13m, down from roughly ~27m
- JRuby 10.0: ~19m, down from roughly ~33m
- TruffleRuby jobs: roughly 8-12m on the post-merge run
- MRI jobs: still roughly 1-4m

The remaining runtime is concentrated in the `kettle-test` step, not setup or appraisal install. Passing `.rspec_status` gives the parallel runner historical example timings so expensive acceptance examples should distribute more evenly across workers.

## Verification

- `env K_SOUP_COV_MIN_HARD=false K_SOUP_COV_DO=false KETTLE_TEST_TURBO_PROCESSES=4 bundle exec kettle-test --example-status-log .rspec_status spec/acceptance/cli/update_spec.rb spec/acceptance/cli/named_appraisal_update_spec.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path); puts path }'`\n- `git diff --check`\n\nNote: `bundle exec rake kettle:jem:selftest` exits successfully in this local environment but reports kettle-jem is disabled, so it does not validate drift here.\n