### PR TITLE
Cache RSpec status logs for CI grouping

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -84,10 +84,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-coverage-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-coverage-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-coverage-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }}@current via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -79,6 +79,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }}@current via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}
 

--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -70,5 +70,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -75,10 +75,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-current-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-current-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-current-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/dep-heads.yml
+++ b/.github/workflows/dep-heads.yml
@@ -81,10 +81,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via Appraisal and ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
@@ -130,10 +130,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
@@ -189,10 +189,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-dep-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via Appraisal and ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/dep-heads.yml
+++ b/.github/workflows/dep-heads.yml
@@ -76,6 +76,16 @@ jobs:
         if: ${{ !env.ACT && steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via Appraisal and ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}
@@ -114,6 +124,16 @@ jobs:
           rubygems: ${{ matrix.rubygems }}
           bundler: ${{ matrix.bundler }}
           bundler-cache: true
+
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
@@ -163,6 +183,16 @@ jobs:
         id: bundleAppraisalAttempt2
         if: ${{ !env.ACT && steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
+
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via Appraisal and ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/heads.yml
+++ b/.github/workflows/heads.yml
@@ -80,10 +80,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
@@ -138,10 +138,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
@@ -196,10 +196,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-heads-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/heads.yml
+++ b/.github/workflows/heads.yml
@@ -75,6 +75,16 @@ jobs:
         if: ${{ !env.ACT && steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}
@@ -123,6 +133,16 @@ jobs:
         if: ${{ !env.ACT && steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}
@@ -170,6 +190,16 @@ jobs:
         id: bundleAppraisalAttempt2
         if: ${{ !env.ACT && steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
+
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/jruby-10.0.yml
+++ b/.github/workflows/jruby-10.0.yml
@@ -74,6 +74,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/jruby-10.0.yml
+++ b/.github/workflows/jruby-10.0.yml
@@ -79,10 +79,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-jruby-10.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-jruby-10.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-jruby-10.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/jruby-9.2.yml
+++ b/.github/workflows/jruby-9.2.yml
@@ -84,10 +84,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-jruby-9.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-jruby-9.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-jruby-9.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/jruby-9.2.yml
+++ b/.github/workflows/jruby-9.2.yml
@@ -79,6 +79,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/jruby-9.3.yml
+++ b/.github/workflows/jruby-9.3.yml
@@ -84,10 +84,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-jruby-9.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-jruby-9.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-jruby-9.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/jruby-9.3.yml
+++ b/.github/workflows/jruby-9.3.yml
@@ -79,6 +79,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/jruby-9.4.yml
+++ b/.github/workflows/jruby-9.4.yml
@@ -73,6 +73,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/jruby-9.4.yml
+++ b/.github/workflows/jruby-9.4.yml
@@ -78,10 +78,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-jruby-9.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-jruby-9.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-jruby-9.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -74,6 +74,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -79,10 +79,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-jruby-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-jruby-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-jruby-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/ruby-2.4.yml
+++ b/.github/workflows/ruby-2.4.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-2.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-2.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-2.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-2.4.yml
+++ b/.github/workflows/ruby-2.4.yml
@@ -64,5 +64,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-2.5.yml
+++ b/.github/workflows/ruby-2.5.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-2.5-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-2.5-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-2.5-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-2.5.yml
+++ b/.github/workflows/ruby-2.5.yml
@@ -64,5 +64,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-2.6.yml
+++ b/.github/workflows/ruby-2.6.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-2.6-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-2.6-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-2.6-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-2.6.yml
+++ b/.github/workflows/ruby-2.6.yml
@@ -64,5 +64,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-2.7.yml
+++ b/.github/workflows/ruby-2.7.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-2.7-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-2.7-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-2.7-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-2.7.yml
+++ b/.github/workflows/ruby-2.7.yml
@@ -64,5 +64,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.0.yml
+++ b/.github/workflows/ruby-3.0.yml
@@ -73,10 +73,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-3.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-3.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-3.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/ruby-3.0.yml
+++ b/.github/workflows/ruby-3.0.yml
@@ -68,6 +68,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.1.yml
+++ b/.github/workflows/ruby-3.1.yml
@@ -67,5 +67,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.1.yml
+++ b/.github/workflows/ruby-3.1.yml
@@ -72,10 +72,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-3.1-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-3.1-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-3.1-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.2.yml
+++ b/.github/workflows/ruby-3.2.yml
@@ -64,5 +64,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} ${{ matrix.appraisal }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.2.yml
+++ b/.github/workflows/ruby-3.2.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-3.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-3.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-3.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} ${{ matrix.appraisal }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.3.yml
+++ b/.github/workflows/ruby-3.3.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-3.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-3.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-3.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} ${{ matrix.appraisal }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.3.yml
+++ b/.github/workflows/ruby-3.3.yml
@@ -64,5 +64,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} ${{ matrix.appraisal }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.4.yml
+++ b/.github/workflows/ruby-3.4.yml
@@ -69,10 +69,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-ruby-3.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-ruby-3.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-ruby-3.4-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} ${{ matrix.appraisal }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/ruby-3.4.yml
+++ b/.github/workflows/ruby-3.4.yml
@@ -64,5 +64,15 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} ${{ matrix.appraisal }} via ${{ matrix.exec_cmd }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/truffle.yml
+++ b/.github/workflows/truffle.yml
@@ -74,6 +74,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/truffle.yml
+++ b/.github/workflows/truffle.yml
@@ -79,10 +79,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-truffle-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-truffle-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-truffle-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/truffleruby-22.3.yml
+++ b/.github/workflows/truffleruby-22.3.yml
@@ -80,10 +80,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-truffleruby-22.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-truffleruby-22.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-truffleruby-22.3-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/truffleruby-22.3.yml
+++ b/.github/workflows/truffleruby-22.3.yml
@@ -75,6 +75,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/truffleruby-23.0.yml
+++ b/.github/workflows/truffleruby-23.0.yml
@@ -80,10 +80,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-truffleruby-23.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-truffleruby-23.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-truffleruby-23.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/truffleruby-23.0.yml
+++ b/.github/workflows/truffleruby-23.0.yml
@@ -75,6 +75,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/truffleruby-23.1.yml
+++ b/.github/workflows/truffleruby-23.1.yml
@@ -61,6 +61,16 @@ jobs:
           bundler: ${{ matrix.bundler }}
           bundler-cache: true
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/truffleruby-23.1.yml
+++ b/.github/workflows/truffleruby-23.1.yml
@@ -66,10 +66,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-truffleruby-23.1-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-truffleruby-23.1-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-truffleruby-23.1-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/truffleruby-24.2.yml
+++ b/.github/workflows/truffleruby-24.2.yml
@@ -74,6 +74,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/truffleruby-24.2.yml
+++ b/.github/workflows/truffleruby-24.2.yml
@@ -79,10 +79,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-truffleruby-24.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-truffleruby-24.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-truffleruby-24.2-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/truffleruby-25.0.yml
+++ b/.github/workflows/truffleruby-25.0.yml
@@ -80,6 +80,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/truffleruby-25.0.yml
+++ b/.github/workflows/truffleruby-25.0.yml
@@ -85,10 +85,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-truffleruby-25.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-truffleruby-25.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-truffleruby-25.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/.github/workflows/truffleruby-33.0.yml
+++ b/.github/workflows/truffleruby-33.0.yml
@@ -74,6 +74,16 @@ jobs:
         if: ${{ steps.bundleAppraisalAttempt1.outcome == 'failure' && !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} install
 
+      - name: Restore RSpec status log
+        if: ${{ !env.ACT }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .rspec_status
+          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}
         run: bundle exec appraisal ${{ matrix.appraisal }} bundle exec ${{ matrix.exec_cmd }}

--- a/.github/workflows/truffleruby-33.0.yml
+++ b/.github/workflows/truffleruby-33.0.yml
@@ -79,10 +79,10 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .rspec_status
-          key: rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: rspec-status-truffleruby-33.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
-            rspec-status-${{ github.workflow }}-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
+            rspec-status-truffleruby-33.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles('**/Gemfile.lock', 'Appraisal.root.gemfile', 'gemfiles/**/*.gemfile') }}-
+            rspec-status-truffleruby-33.0-${{ runner.os }}-${{ matrix.ruby }}-${{ matrix.appraisal }}-
 
       - name: Tests for ${{ matrix.ruby }} via ${{ matrix.exec_cmd }}
         if: ${{ !env.ACT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ Please file a bug if you notice a violation of semantic versioning.
   deprecated implicit full-update form.
 - Acceptance specs now opt into expensive dummy-gem and bundle fixture setup
   through metadata, and reuse a per-worker cached default fixture stage.
-- Generated CI workflows now pass `.rspec_status` to `kettle-test` so
-  `turbo_tests2` can balance workers with historical example timings.
+- Generated CI workflows now cache `.rspec_status` and pass it to
+  `kettle-test` so `turbo_tests2` can balance workers with historical example
+  timings.
 - `generate-install` and `generate-update` now reuse the parsed Appraisals set
   for their generate and install/update phases.
 


### PR DESCRIPTION
## Summary

- restore and save `.rspec_status` in CI workflows that pass it to `kettle-test`
- key the cache by workflow, OS, Ruby, appraisal, lockfile/appraisal gemfile hash, and run attempt
- clarify the changelog entry so historical timings come from the cache plus `--example-status-log`

This addresses the review comments left on merged PR #49. The branch is intentionally named `jruby/cache-rspec-status-log` so JRuby workflows run on the PR.

## Verification

- `env K_SOUP_COV_MIN_HARD=false K_SOUP_COV_DO=false KETTLE_TEST_TURBO_PROCESSES=4 bundle exec kettle-test --example-status-log .rspec_status spec/acceptance/cli/update_spec.rb spec/acceptance/cli/named_appraisal_update_spec.rb`
- `ruby -ryaml -e 'Dir[".github/workflows/*.yml"].each { |path| YAML.load_file(path); puts path }'`\n- `git diff --check`\n\nI also ran `bundle exec kettle-gha-sha-pins --check`. The new `actions/cache` pin resolves, but the command exits nonzero on pre-existing `actions/checkout` version-comment normalization (`v7.0.0` -> `v7`), which is unrelated to this change.\n